### PR TITLE
FEAT: Stratified K-Fold Cross-Validation 과 앙상블 기능 추가

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,4 +1,4 @@
-from model import inference
+from model import inference, kfold_inference
 import argparse
 
 
@@ -75,6 +75,18 @@ def get_config():
         type=str,
         default="result",
     )
+    
+    parser.add_argument(
+        "--K_Fold",
+        type=int,
+        default=5,
+    )
+    
+    parser.add_argument(
+        "--K_Fold_Inference",
+        type=bool,
+        default=False
+    )
 
     config = parser.parse_args()
     return config
@@ -82,5 +94,8 @@ def get_config():
 
 if __name__ == "__main__":
     inference_config = get_config()
-
-    inference(inference_config)
+    
+    if inference_config.K_Fold_Inference:
+        kfold_inference(inference_config)
+    else:
+        inference(inference_config)

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import os
 from huggingface_hub import login
 from dotenv import load_dotenv
 
-from model import do_train
+from model import do_train, kfold_do_train
 from utils import set_experiment_dir
 
 
@@ -168,6 +168,18 @@ def get_config():
         choices=[0, 1],
         type=int,
     )
+    
+    parser.add_argument(
+        "--K_Fold",
+        type=int,
+        default=5,
+    )
+    
+    parser.add_argument(
+        "--K_Fold_Train",
+        type=bool,
+        default=False
+    )
 
     config = parser.parse_args()
 
@@ -191,5 +203,8 @@ if __name__ == "__main__":
     #     project=config.project_name,
     #     name=config.run_name,
     # )
-    do_train(config)
+    if config.K_Fold_Train:
+        kfold_do_train(config)
+    else:
+        do_train(config)
     # wandb.finish()

--- a/train2infer.sh
+++ b/train2infer.sh
@@ -20,6 +20,7 @@ python3 main.py \
   --neftune-noise-alpha 5 \
   --patience 3 \
   --test-run 1 \
+  --K_Fold_Train True \
 
 python3 inference.py \
   --use-local-zip 1 \
@@ -29,4 +30,5 @@ python3 inference.py \
   --save-dir model \
   --model-name beomi/korean-hatespeech-multilabel \
   --max-len 20 \
-  --test-run 1
+  --test-run 1 \
+  --K_Fold_Inference True


### PR DESCRIPTION
### 제목
FEAT: Stratified K-Fold Cross-Validation 과 앙상블 기능 추가

### 설명
Stratified K-Fold Cross-Validation 기능을 추가하였습니다.
사용자가 이용하기 쉽게 K-Fold 용 함수를 몇 가지 추가하여 K-Fold를 사용하지 않을 때 쉘파일만 변경하면 되도록 코드를 작성하였습니다.
또한 K-Fold 후 자동으로 앙상블## 제목

### 설명
1. Stratified K-Fold Cross-Validation 기능을 추가하였습니다.
2. 사용자가 이용하기 쉽게 K-Fold 용 함수를 몇 가지 추가하여 K-Fold를 사용하지 않을 때 쉘파일만 변경하면 되도록 코드를 작성하였습니다. 
3. K-Fold 후 자동으로 앙상블이 적용되도록 하였습니다

### 변경 내용
**- data.py**
kfold_datasets 함수 생성
**- model.py**
KFold_load_model_and_tokenizer_for_inference, ensemble, kfold_do_train, kfold_inference 함수 생성
**- main.py**
K_Fold 와 관련된 augument 두 개 추가
K_Fold _Train 값에 따라 일반학습과 K_Fold 학습으로 분기처리
**- inference.py**
K_Fold 와 관련된 augument 두 개 추가
K_Fold _Inference 값에 따라 일반학습과 K_Fold 학습으로 분기처리
**- train2infer.sh**
K_Fold_Train, K_Fold_Inference 추가

### 테스트 방법
- NIKL_AU_2023_v1.0_JSONL.zip 을 추가한 후 train2infer.sh 을 실행
- 터미널에 나오는 출력문을 통해 확인 가능
- ex) --------Training fold 1--------
- 
### 관련 이슈
- 앙상블 관련된 코드는 ChatGPT를 기반으로 작성되었기 때문에 현재 5개의 결과 파일을 합치는 식이기 때문에 여러 조합의 앙상블을 하여 최적의 조합을 찾기 위해서는 수정이 필요합니다.
- 현재 하이퍼파라미터로는 K-Fold과 앙상블을 적용시켰을 경우 성능이 감소하는 경향이 있기 때문에 K-Fold에 맞는 하이퍼파라미터 변경이 필요합니다.